### PR TITLE
Trigger resque before_dequeue and after_dequeue hooks

### DIFF
--- a/lib/resque-serializer.rb
+++ b/lib/resque-serializer.rb
@@ -1,4 +1,5 @@
 require 'resque-serializer/version'
+require 'resque-serializer/monkey_patches/resque'
 require 'resque-serializer/mutex'
 require 'resque-serializer/serializers/both'
 require 'resque-serializer/serializers/combined'

--- a/lib/resque-serializer/monkey_patches/resque.rb
+++ b/lib/resque-serializer/monkey_patches/resque.rb
@@ -1,0 +1,36 @@
+module ResqueSerializer
+  module MonkeyPatches
+    module Resque
+      # NOTE: `Resque#pop` is called when working queued jobs via the
+      # `resque:work` rake task. Resque's default implementation will
+      # not trigger the `before_dequeue` or `after_dequeue` hooks;
+      # this patch will force it do so.
+      def pop(queue)
+        return unless (job_details = decode(data_store.pop_from_queue(queue)))
+        klass  = job_details['class'].safe_constantize
+        args   = job_details['args']
+
+        # Perform before_dequeue hooks. Don't perform dequeue if any hook
+        # returns false
+        # rubocop:disable Metrics/LineLength
+        before_hooks = ::Resque::Plugin.before_dequeue_hooks(klass).collect do |hook|
+          klass.send(hook, *args)
+        end
+
+        return job_details if before_hooks.any? { |result| result == false }
+
+        ::Resque::Plugin.after_dequeue_hooks(klass).each do |hook|
+          klass.send(hook, *args)
+        end
+
+        job_details
+      end
+    end
+  end
+end
+
+module Resque
+  prepend ResqueSerializer::MonkeyPatches::Resque
+
+  module_function :pop
+end

--- a/resque-serializer.gemspec
+++ b/resque-serializer.gemspec
@@ -25,6 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry-byebug'
   gem.add_development_dependency 'pry-stack_explorer'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'resque_spec'
   gem.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/spec/lib/resque-serializer/monkey_patches/resque_spec.rb
+++ b/spec/lib/resque-serializer/monkey_patches/resque_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+class ResqueDequeueHookJob
+  extend Resque::Plugins::Serializer
+
+  serialize :both
+
+  @queue = :default
+
+  def self.perform(*args); end
+end
+
+RSpec.describe ResqueDequeueHookJob do
+  let(:args)          { %w[arg1 arg2] }
+  let(:queue_name)    { :default }
+  let(:dequeue_hooks) { [] }
+
+  before do
+    allow(Resque::Plugin)
+      .to receive(:before_dequeue_hooks)
+      .and_return(dequeue_hooks)
+    allow(Resque::Plugin)
+      .to receive(:after_dequeue_hooks)
+      .and_return(dequeue_hooks)
+    enqueue_job
+  end
+
+  it 'executes the dequeue hooks' do
+    expect(::Resque::Plugin).to receive(:before_dequeue_hooks).ordered
+    expect(::Resque::Plugin).to receive(:after_dequeue_hooks).ordered
+
+    execute_job
+  end
+end

--- a/spec/lib/resque-serializer/serializers/both_spec.rb
+++ b/spec/lib/resque-serializer/serializers/both_spec.rb
@@ -21,107 +21,64 @@ class JobSerializedByBoth
 end
 
 RSpec.describe JobSerializedByBoth do
-  let(:args) { %w(arg1 arg2) }
+  let(:args)       { %w[arg1 arg2] }
+  let(:queue_name) { :default }
 
   before do
-    ResqueSpec.reset!
     Resque.redis.redis.flushall
   end
 
-  describe 'before enqueuing the job' do
-    let(:mutex) { described_class.queue_mutex(args) }
-
-    subject(:enqueue_job) { Resque.enqueue(described_class, *args) }
-
-    context 'when a lock for the job exists' do
-      before { mutex.lock! }
-
-      it 'does not enqueue the job' do
-        expect { enqueue_job }.to_not change {
-          ResqueSpec.queue_for(described_class).size
-        }.from(0)
-      end
-
-      it 'does not unlock the mutex' do
-        expect { enqueue_job }.to_not change {
-          mutex.locked?
-        }.from(true)
-      end
-    end
-
-    context 'when a lock for the job does not exist' do
-      it 'enqueues the job' do
-        expect { enqueue_job }.to change {
-          ResqueSpec.queue_for(described_class).size
-        }.from(0).to(1)
-      end
-
-      it 'locks the mutex' do
-        expect { enqueue_job }.to change {
-          mutex.locked?
-        }.from(false).to(true)
-      end
-    end
-  end
-
-  describe 'after dequeuing the job' do
-    let(:mutex) { described_class.queue_mutex(args) }
-
-    subject(:dequeue_job) { Resque.dequeue(described_class, *args) }
-
-    before { mutex.lock! }
-
-    it 'unlocks the mutex' do
-      expect { dequeue_job }.to change {
-        mutex.locked?
-      }.from(true).to(false)
-    end
-  end
-
-  describe 'before dequeuing the job' do
-    let(:mutex) { described_class.job_mutex(args) }
-
-    subject(:dequeue_job) { Resque.dequeue(described_class, *args) }
-
-    it 'locks the mutex' do
-      expect { dequeue_job }.to change {
-        mutex.locked?
-      }.from(false).to(true)
-    end
-  end
-
-  describe 'after performing the job' do
-    let(:mutex) { described_class.job_mutex(args) }
-
+  context 'with no jobs in the queue' do
     before do
-      Resque.enqueue(described_class, *args)
-      mutex.lock!
+      expect(queue_size).to eq(0)
     end
 
-    subject(:perform_job) { ResqueSpec.perform_next(:default) }
-
-    context 'if the job completes successfully' do
-      it 'releases the lock after execution' do
-        expect { perform_job }.to change {
-          mutex.locked?
-        }.from(true).to(false)
-      end
+    it 'can enqueue the job' do
+      expect { enqueue_job }.to change {
+        queue_size
+      }.from(0).to(1)
     end
 
-    context 'if the job raises an exception' do
-      let(:error) { StandardError }
+    it 'can not execute any jobs' do
+      expect(execute_job).to be_nil
+    end
+  end
 
-      before do
-        allow(described_class).to receive(:perform).and_raise(error)
-      end
+  context 'with one job in the queue' do
+    before do
+      enqueue_job
+      expect(queue_size).to eq(1)
+    end
 
-      it 'still releases the lock after execution' do
-        expect(mutex.locked?).to eq(true)
+    it 'cannot enqueue the same job' do
+      expect { enqueue_job }.to_not change {
+        queue_size
+      }.from(1)
+    end
 
-        expect { perform_job }.to raise_error(error)
+    it 'can execute the job' do
+      expect(execute_job).to_not be_nil
+    end
+  end
 
-        expect(mutex.locked?).to eq(false)
-      end
+  context 'with one job in the queue and one job being executed' do
+    before do
+      enqueue_job
+      expect(queue_size).to eq(1)
+      execute_job
+      expect(queue_size).to eq(0)
+      enqueue_job
+      expect(queue_size).to eq(1)
+    end
+
+    it 'cannot enqueue the same job' do
+      expect { enqueue_job }.to_not change {
+        queue_size
+      }.from(1)
+    end
+
+    it 'can execute the job' do
+      expect(execute_job).to_not be_nil
     end
   end
 end

--- a/spec/lib/resque-serializer/serializers/combined_spec.rb
+++ b/spec/lib/resque-serializer/serializers/combined_spec.rb
@@ -21,81 +21,58 @@ class JobSerializedByCombined
 end
 
 RSpec.describe JobSerializedByCombined do
-  let(:args) { %w(arg1 arg2) }
+  let(:args)       { %w[arg1 arg2] }
+  let(:queue_name) { :default }
 
   before do
-    ResqueSpec.reset!
     Resque.redis.redis.flushall
   end
 
-  describe 'before enqueuing the job' do
-    let(:mutex) { described_class.mutex(args) }
-
-    subject(:enqueue_job) { Resque.enqueue(described_class, *args) }
-
-    context 'when a lock for the job exists' do
-      before { mutex.lock! }
-
-      it 'does not enqueue the job' do
-        expect { enqueue_job }.to_not change {
-          ResqueSpec.queue_for(described_class).size
-        }.from(0)
-      end
-
-      it 'does not change the mutex' do
-        expect { enqueue_job }.to_not change {
-          mutex.locked?
-        }.from(true)
-      end
+  context 'with no jobs in the queue' do
+    before do
+      expect(queue_size).to eq(0)
     end
 
-    context 'when a lock for the job does not exist' do
-      before { mutex.unlock }
-
-      it 'enqueues the job' do
-        expect { enqueue_job }.to change {
-          ResqueSpec.queue_for(described_class).size
-        }.from(0).to(1)
-      end
-
-      it 'locks the mutex' do
-        expect { enqueue_job }.to change {
-          mutex.locked?
-        }.from(false).to(true)
-      end
+    it 'can enqueue the job' do
+      expect { enqueue_job }.to change {
+        queue_size
+      }.from(0).to(1)
     end
   end
 
-  describe 'after performing the job' do
-    let(:mutex) { described_class.mutex(args) }
+  context 'with one job in the queue' do
+    before do
+      enqueue_job
+      expect(queue_size).to eq(1)
+    end
+
+    it 'cannot enqueue the same job' do
+      expect { enqueue_job }.to_not change {
+        queue_size
+      }.from(1)
+    end
+
+    it 'can execute the job' do
+      expect(execute_job).to_not be_nil
+    end
+  end
+
+  context 'with one job in the queue and one job being executed' do
+    let(:execute_job) { worker.reserve.perform }
 
     before do
-      # Note: this locks the mutex on the :before_enqueue_* hook
-      Resque.enqueue(described_class, *args)
+      enqueue_job
+      expect(queue_size).to eq(1)
+      execute_job
+      expect(queue_size).to eq(0)
+      enqueue_job
+      expect(queue_size).to eq(1)
     end
 
-    subject(:perform_job) { ResqueSpec.perform_next(:default) }
-
-    context 'when the job completes successfully' do
-      it 'releases the lock after execution' do
-        expect { perform_job }.to change {
-          mutex.locked?
-        }.from(true).to(false)
-      end
-    end
-
-    context 'when the job raises an exception' do
-      let(:error) { StandardError }
-
-      before { allow(described_class).to receive(:perform).and_raise(error) }
-
-      it 'still releases the lock after execution' do
-        expect(mutex.locked?).to eq(true)
-
-        expect { perform_job }.to raise_error(error)
-
-        expect(mutex.locked?).to eq(false)
-      end
+    it 'cannot enqueue the same job' do
+      expect { enqueue_job }.to_not change {
+        queue_size
+      }.from(1)
     end
   end
 end

--- a/spec/resque_test_helper.rb
+++ b/spec/resque_test_helper.rb
@@ -1,0 +1,17 @@
+module ResqueTestHelper
+  def enqueue_job
+    Resque.enqueue(described_class, *args)
+  end
+
+  def queue_size
+    Resque.size(queue_name)
+  end
+
+  def worker
+    Resque::Worker.new(queue_name)
+  end
+
+  def execute_job
+    worker.reserve
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,8 @@ require 'resque-serializer'
 require 'bundler/setup'
 require 'mock_redis'
 require 'resque'
-require 'resque_spec'
 require 'pry-byebug'
+require 'resque_test_helper'
 
 RSpec.configure do |config|
   config.expect_with(:rspec) do |c|
@@ -14,4 +14,6 @@ RSpec.configure do |config|
   config.before(:suite) do
     Resque.redis = MockRedis.new
   end
+
+  config.include ResqueTestHelper
 end


### PR DESCRIPTION
### Description
* `Resque#pop` is called when working queued jobs via the `resque:work` rake task. Resque's default implementation will not trigger the `before_dequeue` or `after_dequeue` hooks; this patch will force it do so

### Tasks
 - [x] Verify if fix is working as expected in the repositories which uses resque-serializer

### References
 - related to github issue where before_dequeue and after dequeue are not working as expected
   https://github.com/resque/resque/issues/512