### PR TITLE
Adds `Resque::Plugins::Serializer::Configuration`

### DIFF
--- a/lib/resque-serializer.rb
+++ b/lib/resque-serializer.rb
@@ -1,3 +1,5 @@
+require 'resque'
+require 'resque-serializer/configuration'
 require 'resque-serializer/version'
 require 'resque-serializer/monkey_patches/resque'
 require 'resque-serializer/mutex'
@@ -9,6 +11,16 @@ require 'resque-serializer/serializers/queue'
 module Resque
   module Plugins
     module Serializer
+      class << self
+        attr_accessor :configuration
+
+        def configure(&block)
+          self.configuration ||= Configuration.instance
+
+          yield(configuration)
+        end
+      end
+
       def serialize(resource)
         case resource
         when :job      then extend(Serializers::Job)
@@ -31,3 +43,6 @@ module Resque
     end
   end
 end
+
+# Use default configuration
+Resque::Plugins::Serializer.configure {}

--- a/lib/resque-serializer/configuration.rb
+++ b/lib/resque-serializer/configuration.rb
@@ -1,0 +1,17 @@
+module Resque
+  module Plugins
+    module Serializer
+      class Configuration
+        include Singleton
+
+        attr_accessor :mutex_generator
+
+        DEFAULT_MUTEX_GENERATOR = ->(key) { Serializer::Mutex.new(key) }
+
+        def initialize
+          @mutex_generator = DEFAULT_MUTEX_GENERATOR
+        end
+      end
+    end
+  end
+end

--- a/lib/resque-serializer/serializers/both.rb
+++ b/lib/resque-serializer/serializers/both.rb
@@ -32,15 +32,21 @@ module Resque
             job_mutex(args).unlock
           end
 
+          private
+
+          delegate :configuration,
+            to: Resque::Plugins::Serializer
+
+          delegate :mutex_generator,
+            to: :configuration
+
           def queue_mutex(args)
-            Serializer::Mutex.new(queue_key(args))
+            mutex_generator.call(queue_key(args))
           end
 
           def job_mutex(args)
-            Serializer::Mutex.new(job_key(args))
+            mutex_generator.call(job_key(args))
           end
-
-          private
 
           def queue_key(args)
             klass = self.name.tableize.singularize

--- a/lib/resque-serializer/serializers/combined.rb
+++ b/lib/resque-serializer/serializers/combined.rb
@@ -24,11 +24,17 @@ module Resque
             mutex(args).unlock
           end
 
-          def mutex(args)
-            Serializer::Mutex.new(key(args))
-          end
-
           private
+
+          delegate :configuration,
+            to: Resque::Plugins::Serializer
+
+          delegate :mutex_generator,
+            to: :configuration
+
+          def mutex(args)
+            mutex_generator.call(key(args))
+          end
 
           def key(args)
             klass = self.name.tableize.singularize

--- a/lib/resque-serializer/serializers/job.rb
+++ b/lib/resque-serializer/serializers/job.rb
@@ -24,11 +24,17 @@ module Resque
             mutex(args).unlock
           end
 
-          def mutex(args)
-            Serializer::Mutex.new(key(args))
-          end
-
           private
+
+          delegate :configuration,
+            to: Resque::Plugins::Serializer
+
+          delegate :mutex_generator,
+            to: :configuration
+
+          def mutex(args)
+            mutex_generator.call(key(args))
+          end
 
           def key(args)
             klass = self.name.tableize.singularize

--- a/lib/resque-serializer/serializers/queue.rb
+++ b/lib/resque-serializer/serializers/queue.rb
@@ -22,11 +22,17 @@ module Resque
             mutex(args).unlock
           end
 
-          def mutex(args)
-            Serializer::Mutex.new(key(args))
-          end
-
           private
+
+          delegate :configuration,
+            to: Resque::Plugins::Serializer
+
+          delegate :mutex_generator,
+            to: :configuration
+
+          def mutex(args)
+            mutex_generator.call(key(args))
+          end
 
           def key(args)
             klass = self.name.tableize.singularize

--- a/spec/lib/resque-serializer/configuration_spec.rb
+++ b/spec/lib/resque-serializer/configuration_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Resque::Plugins::Serializer::Configuration do
+  describe 'instance methods' do
+    describe '#mutex_generator' do
+      let(:instance) { described_class.instance }
+      let(:key)      { 'key' }
+
+      context 'when called' do
+        subject { instance.mutex_generator.call(key) }
+
+        it 'returns an instance of the mutex' do
+          expect(subject).to be_a(Resque::Plugins::Serializer::Mutex)
+
+          expect(subject).to have_attributes(key: key)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adds a `Resque::Plugins::Serializer::Configuration` class to hold gem
configuration. It currently includes a `generate_mutex` option (which expects a
proc) for customizing how the mutex is generated. The resulting mutex is
expected to respond to `#lock` & `#unlock`.

### Risks
 * **Low**: Current behavior is the maintained as the default behavior.